### PR TITLE
Add `list-remote` (alias `ls-remote`) command to verman

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ export PATH="$HOME/.spin_verman/versions/current_version:$PATH"
 
 Once the path is prepended, you can try the below commands:
 
+## List available versions of Spin
+
+```sh
+# list all available versions of spin
+spin verman list-remote
+```
+
 ## Download a specific version of Spin
 
 Specify the desired version:

--- a/cmd/listremote.go
+++ b/cmd/listremote.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var listRemoteCmd = &cobra.Command{
+	Use:     "list-remote",
+	Aliases: []string{"ls-remote"},
+	Short:   "Lists all available versions of Spin",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		err := listRemote()
+		if err != nil {
+			fmt.Printf("Error while loading available Spin version\n%v\n", err)
+			os.Exit(1)
+		}
+
+		return nil
+	},
+}
+
+const (
+	spinReleasesUrl   = "https://api.github.com/repos/fermyon/spin/releases"
+	githubTokenEnvVar = "GH_TOKEN"
+)
+
+func listRemote() error {
+	fmt.Fprintf(os.Stderr, "Fetching available Spin releases ...\n\n")
+	releases, err := loadSpinReleases()
+	if err != nil {
+		return err
+	}
+	for _, release := range *releases {
+		tagName := strings.Replace(release.TagName, "v", "", 1)
+		fmt.Printf("%s\n", tagName)
+	}
+	return nil
+}
+
+func loadSpinReleases() (*[]spinRelease, error) {
+	req, err := http.NewRequest("GET", spinReleasesUrl, nil)
+	if err != nil {
+		log.Fatalf("Failed to create request: %v", err)
+	}
+	token := os.Getenv(githubTokenEnvVar)
+	if len(token) > 0 {
+		req.Header.Set("Authorization", fmt.Sprintf("token %s", token))
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to load available Spin releases")
+	}
+	defer resp.Body.Close()
+
+	// the value stored in env GH_TOKEN is a bad credential
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, fmt.Errorf("Unauthorized: Bad credentials. Please check your GitHub token (%s).", githubTokenEnvVar)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to read response body: %v", err)
+	}
+	var releases []spinRelease
+	err = json.Unmarshal(body, &releases)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to unmarshal JSON: %v", err)
+	}
+	return &releases, nil
+}
+
+type spinRelease struct {
+	TagName string `json:"tag_name"`
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,6 +26,8 @@ func init() {
 	rootCmd.AddCommand(getCmd)
 	// List
 	rootCmd.AddCommand(listCmd)
+	// List Remote
+	rootCmd.AddCommand(listRemoteCmd)
 	// Remove
 	removeCmd.AddCommand(removeAllCmd)
 	removeCmd.AddCommand(removeCurrentCmd)


### PR DESCRIPTION
This PR adds the `list-remote` (alias `ls-remote`) to the version manager plugin, allowing users to see which versions of Spin could be installed on their system.

Fixes #8