### PR TITLE
Add support for `.spinrc`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 verman
+!internal/verman
 *.json
 *.tar.gz

--- a/README.md
+++ b/README.md
@@ -79,22 +79,22 @@ Set the latest version:
 spin verman set latest
 ```
 
-## Using `.spinrc` to Download and Set the desired Spin version
+## Using `.spin-version` to Download and Set the desired Spin version
 
-You can specify the desired version of Spin in a `.spinrc` file. The `verman` plugin is able to download and set the current version from a `.spinrc` file:
+You can specify the desired version of Spin in a `.spin-version` file. The `verman` plugin is able to download and set the current version from a `.spin-version` file:
 
 ```bash
-# Specify desired version in a .spinrc file
-echo "2.7.0" > .spinrc
+# Specify desired version in a .spin-version file
+echo "2.7.0" > .spin-version
 
-# Download the spin version specified in .spinrc
+# Download the spin version specified in .spin-version
 spin verman get
 
-# Set the version of spin specified in .spinrc
+# Set the version of spin specified in .spin-version
 spin verman set
 ```
 
-*Note: Arguments are provided to either `spin verman get` or `spin verman set` have higher priority compared to `.spinrc`.*
+*Note: Arguments are provided to either `spin verman get` or `spin verman set` have higher priority compared to `.spin-version`.*
 
 ## Update a version of Spin in the `~/.spin_verman` directory
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,23 @@ Set the latest version:
 spin verman set latest
 ```
 
+## Using `.spinrc` to Download and Set the desired Spin version
+
+You can specify the desired version of Spin in a `.spinrc` file. The `verman` plugin is able to download and set the current version from a `.spinrc` file:
+
+```bash
+# Specify desired version in a .spinrc file
+echo "2.7.0" > .spinrc
+
+# Download the spin version specified in .spinrc
+spin verman get
+
+# Set the version of spin specified in .spinrc
+spin verman set
+```
+
+*Note: Arguments are provided to either `spin verman get` or `spin verman set` have higher priority compared to `.spinrc`.*
+
 ## Update a version of Spin in the `~/.spin_verman` directory
 
 ```sh

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/fermyon/verman-plugin/internal/verman"
 	"github.com/spf13/cobra"
 )
 
@@ -22,8 +23,9 @@ var getCmd = &cobra.Command{
 	Short: "Downloads the binary for the requested version if not found locally.",
 	Long:  "Downloads the binary for the requested version if not found locally. Multiple versions can be downloaded at once: \"spin verman get 2.1.0 canary\".",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) == 0 {
-			return fmt.Errorf("you must indicate the version of Spin you wish to set")
+		versions, err := verman.GetDesiredVersionsForGet(args)
+		if err != nil {
+			return err
 		}
 
 		versionDir, err := getVersionDir()
@@ -31,7 +33,7 @@ var getCmd = &cobra.Command{
 			return err
 		}
 
-		for _, version := range args {
+		for _, version := range versions {
 			if !strings.HasPrefix(version, "v") && version != "canary" {
 				version = "v" + version
 			}

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/fermyon/verman-plugin/internal/verman"
 	"github.com/spf13/cobra"
 )
 
@@ -15,11 +16,10 @@ var setCmd = &cobra.Command{
 	Short: "Sets Spin to the requested version.",
 	Long:  "Sets Spin to the requested version, and will download the binary for the requested version if not found locally.",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) == 0 {
-			return fmt.Errorf("you must indicate the version of Spin you wish to set")
+		version, err := verman.GetDesiredVersionForSet(args)
+		if err != nil {
+			return err
 		}
-
-		version := args[0]
 
 		if !strings.HasPrefix(version, "v") && version != "canary" {
 			version = "v" + version

--- a/internal/verman/verman.go
+++ b/internal/verman/verman.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	rcFileName = ".spinrc"
+	spinVersionFileName = ".spin-version"
 )
 
 func GetDesiredVersionForSet(args []string) (string, error) {
@@ -15,7 +15,7 @@ func GetDesiredVersionForSet(args []string) (string, error) {
 	if len(args) > 0 {
 		return args[0], nil
 	}
-	rcVersion := getVersionFromRcFile()
+	rcVersion := getVersionFromSpinVersionFile()
 
 	// if rc version is empty, return an error
 	if len(rcVersion) == 0 {
@@ -29,7 +29,7 @@ func GetDesiredVersionsForGet(args []string) ([]string, error) {
 	if len(args) > 0 {
 		return args, nil
 	}
-	rcVersion := getVersionFromRcFile()
+	rcVersion := getVersionFromSpinVersionFile()
 
 	// if rc version is empty, return an error
 	if len(rcVersion) == 0 {
@@ -38,13 +38,13 @@ func GetDesiredVersionsForGet(args []string) ([]string, error) {
 	return []string{rcVersion}, nil
 }
 
-func getVersionFromRcFile() string {
-	_, err := os.Stat(rcFileName)
+func getVersionFromSpinVersionFile() string {
+	_, err := os.Stat(spinVersionFileName)
 	if os.IsNotExist(err) {
 		return ""
 	}
 
-	content, err := os.ReadFile(rcFileName)
+	content, err := os.ReadFile(spinVersionFileName)
 	if err != nil {
 		return ""
 	}

--- a/internal/verman/verman.go
+++ b/internal/verman/verman.go
@@ -1,0 +1,53 @@
+package verman
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+const (
+	rcFileName = ".spinrc"
+)
+
+func GetDesiredVersionForSet(args []string) (string, error) {
+	// explicitly provided ver has higher priority
+	if len(args) > 0 {
+		return args[0], nil
+	}
+	rcVersion := getVersionFromRcFile()
+
+	// if rc version is empty, return an error
+	if len(rcVersion) == 0 {
+		return "", fmt.Errorf("you must indicate the version of Spin you wish to set")
+	}
+	return rcVersion, nil
+}
+
+func GetDesiredVersionsForGet(args []string) ([]string, error) {
+	// explicitly provided ver has higher priority
+	if len(args) > 0 {
+		return args, nil
+	}
+	rcVersion := getVersionFromRcFile()
+
+	// if rc version is empty, return an error
+	if len(rcVersion) == 0 {
+		return nil, fmt.Errorf("you must indicate the version of Spin you wish to set")
+	}
+	return []string{rcVersion}, nil
+}
+
+func getVersionFromRcFile() string {
+	_, err := os.Stat(rcFileName)
+	if os.IsNotExist(err) {
+		return ""
+	}
+
+	content, err := os.ReadFile(rcFileName)
+	if err != nil {
+		return ""
+	}
+
+	return strings.TrimSpace(string(content))
+}

--- a/internal/verman/verman_test.go
+++ b/internal/verman/verman_test.go
@@ -1,0 +1,136 @@
+package verman
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGetDesiredVersionForSet(t *testing.T) {
+	tests := []struct {
+		name          string
+		args          []string
+		rcFileContent string
+		expected      string
+		expectError   bool
+	}{
+		{
+			name:        "Explicit version provided",
+			args:        []string{"1.2.3"},
+			expected:    "1.2.3",
+			expectError: false,
+		},
+		{
+			name:          "No args, version from rc file",
+			args:          []string{},
+			rcFileContent: "2.3.4",
+			expected:      "2.3.4",
+			expectError:   false,
+		},
+		{
+			name:          "No args, empty rc file",
+			args:          []string{},
+			rcFileContent: "",
+			expected:      "",
+			expectError:   true,
+		},
+		{
+			name:        "No args, rc file does not exist",
+			args:        []string{},
+			expected:    "",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.rcFileContent != "" {
+				err := os.WriteFile(rcFileName, []byte(tt.rcFileContent), 0644)
+				if err != nil {
+					t.Fatalf("failed to write rc file: %v", err)
+				}
+				defer os.Remove(rcFileName)
+			} else {
+				os.Remove(rcFileName)
+			}
+
+			version, err := GetDesiredVersionForSet(tt.args)
+			if (err != nil) != tt.expectError {
+				t.Errorf("expected error: %v, got: %v", tt.expectError, err)
+			}
+			if version != tt.expected {
+				t.Errorf("expected version: %v, got: %v", tt.expected, version)
+			}
+		})
+	}
+}
+
+func TestGetDesiredVersionsForGet(t *testing.T) {
+	tests := []struct {
+		name          string
+		args          []string
+		rcFileContent string
+		expected      []string
+		expectError   bool
+	}{
+		{
+			name:        "Explicit versions provided",
+			args:        []string{"1.2.3", "2.3.4"},
+			expected:    []string{"1.2.3", "2.3.4"},
+			expectError: false,
+		},
+		{
+			name:          "No args, version from rc file",
+			args:          []string{},
+			rcFileContent: "2.3.4",
+			expected:      []string{"2.3.4"},
+			expectError:   false,
+		},
+		{
+			name:          "No args, empty rc file",
+			args:          []string{},
+			rcFileContent: "",
+			expected:      nil,
+			expectError:   true,
+		},
+		{
+			name:        "No args, rc file does not exist",
+			args:        []string{},
+			expected:    nil,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.rcFileContent != "" {
+				err := os.WriteFile(rcFileName, []byte(tt.rcFileContent), 0644)
+				if err != nil {
+					t.Fatalf("failed to write rc file: %v", err)
+				}
+				defer os.Remove(rcFileName)
+			} else {
+				os.Remove(rcFileName)
+			}
+
+			versions, err := GetDesiredVersionsForGet(tt.args)
+			if (err != nil) != tt.expectError {
+				t.Errorf("expected error: %v, got: %v", tt.expectError, err)
+			}
+			if !equalStringSlices(versions, tt.expected) {
+				t.Errorf("expected versions: %v, got: %v", tt.expected, versions)
+			}
+		})
+	}
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/verman/verman_test.go
+++ b/internal/verman/verman_test.go
@@ -7,11 +7,11 @@ import (
 
 func TestGetDesiredVersionForSet(t *testing.T) {
 	tests := []struct {
-		name          string
-		args          []string
-		rcFileContent string
-		expected      string
-		expectError   bool
+		name                   string
+		args                   []string
+		spinVersionFileContent string
+		expected               string
+		expectError            bool
 	}{
 		{
 			name:        "Explicit version provided",
@@ -20,21 +20,21 @@ func TestGetDesiredVersionForSet(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name:          "No args, version from rc file",
-			args:          []string{},
-			rcFileContent: "2.3.4",
-			expected:      "2.3.4",
-			expectError:   false,
+			name:                   "No args, version from .spin-version file",
+			args:                   []string{},
+			spinVersionFileContent: "2.3.4",
+			expected:               "2.3.4",
+			expectError:            false,
 		},
 		{
-			name:          "No args, empty rc file",
-			args:          []string{},
-			rcFileContent: "",
-			expected:      "",
-			expectError:   true,
+			name:                   "No args, empty .spin-version file",
+			args:                   []string{},
+			spinVersionFileContent: "",
+			expected:               "",
+			expectError:            true,
 		},
 		{
-			name:        "No args, rc file does not exist",
+			name:        "No args, .spin-version file does not exist",
 			args:        []string{},
 			expected:    "",
 			expectError: true,
@@ -43,14 +43,14 @@ func TestGetDesiredVersionForSet(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.rcFileContent != "" {
-				err := os.WriteFile(rcFileName, []byte(tt.rcFileContent), 0644)
+			if tt.spinVersionFileContent != "" {
+				err := os.WriteFile(spinVersionFileName, []byte(tt.spinVersionFileContent), 0644)
 				if err != nil {
-					t.Fatalf("failed to write rc file: %v", err)
+					t.Fatalf("failed to write .spin-version file: %v", err)
 				}
-				defer os.Remove(rcFileName)
+				defer os.Remove(spinVersionFileName)
 			} else {
-				os.Remove(rcFileName)
+				os.Remove(spinVersionFileName)
 			}
 
 			version, err := GetDesiredVersionForSet(tt.args)
@@ -66,11 +66,11 @@ func TestGetDesiredVersionForSet(t *testing.T) {
 
 func TestGetDesiredVersionsForGet(t *testing.T) {
 	tests := []struct {
-		name          string
-		args          []string
-		rcFileContent string
-		expected      []string
-		expectError   bool
+		name                   string
+		args                   []string
+		spinVersionFileContent string
+		expected               []string
+		expectError            bool
 	}{
 		{
 			name:        "Explicit versions provided",
@@ -79,21 +79,21 @@ func TestGetDesiredVersionsForGet(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name:          "No args, version from rc file",
-			args:          []string{},
-			rcFileContent: "2.3.4",
-			expected:      []string{"2.3.4"},
-			expectError:   false,
+			name:                   "No args, version from .spin-version file",
+			args:                   []string{},
+			spinVersionFileContent: "2.3.4",
+			expected:               []string{"2.3.4"},
+			expectError:            false,
 		},
 		{
-			name:          "No args, empty rc file",
-			args:          []string{},
-			rcFileContent: "",
-			expected:      nil,
-			expectError:   true,
+			name:                   "No args, empty .spin-version file",
+			args:                   []string{},
+			spinVersionFileContent: "",
+			expected:               nil,
+			expectError:            true,
 		},
 		{
-			name:        "No args, rc file does not exist",
+			name:        "No args, .spin-version file does not exist",
 			args:        []string{},
 			expected:    nil,
 			expectError: true,
@@ -102,14 +102,14 @@ func TestGetDesiredVersionsForGet(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.rcFileContent != "" {
-				err := os.WriteFile(rcFileName, []byte(tt.rcFileContent), 0644)
+			if tt.spinVersionFileContent != "" {
+				err := os.WriteFile(spinVersionFileName, []byte(tt.spinVersionFileContent), 0644)
 				if err != nil {
-					t.Fatalf("failed to write rc file: %v", err)
+					t.Fatalf("failed to write .spin-version file: %v", err)
 				}
-				defer os.Remove(rcFileName)
+				defer os.Remove(spinVersionFileName)
 			} else {
-				os.Remove(rcFileName)
+				os.Remove(spinVersionFileName)
 			}
 
 			versions, err := GetDesiredVersionsForGet(tt.args)


### PR DESCRIPTION
This PR adds support for specifying the desired Spin version using a `.spinrc` file. 

It allows developers to pin the desired Spin version for an application. By committing the `.spinrc` file to source control, others can quickly get and set the desired version of Spin for a given app.

## Sample

Consider a Spin App build with version `2.7.0` being created at `~/my-spin-app`. The author creates the `.spinrc` file at `~/my-spin-app/.spinrc`:

```bash
cd ~/my-spin-app
echo "2.7.0" > .spinrc
```

Others can now download the desired version by simply executing `spin verman get` and set it as current version using `spin verman set`

```bash
# assuming the .spinrc exists with a content of 2.7.0
spin verman get
# Spin version v2.7.0 found locally.

spin verman set
# Spin version v2.7.0 found locally.
# Spin has been updated to version v2.7.0

# Modifying .spinrc
echo "2.3.0" > .spinrc

spin verman set
# Spin version v2.3.0 not found locally. Retrieving from source...
# Spin version v2.3.0 was retrieved successfully!
# Spin has been updated to version v2.3.0
```

## Arguments remain to have highest priority

Explicitly specified versions, have highest priority. `spin verman get 2.5.0` will download version `2.5.0` and ignore what is specified in `.spinrc`. Same applies for `spin verman set 2.5.0`

Fixes #9 

