### PR TITLE
Replace semver check

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -11,11 +11,11 @@ import (
 	"os"
 	"path"
 	"runtime"
-	"strconv"
 	"strings"
 
 	"github.com/fermyon/verman-plugin/internal/verman"
 	"github.com/spf13/cobra"
+	"golang.org/x/mod/semver"
 )
 
 var getCmd = &cobra.Command{
@@ -292,15 +292,5 @@ func unpackSpin(directory, tarGzFileName, version string) error {
 
 // isSemver makes sure the version passed is proper semver
 func isSemver(version string) bool {
-	isInt := func(val string) bool {
-		_, err := strconv.ParseInt(val, 10, 64)
-		return err == nil
-	}
-
-	versionArray := strings.Split(version, ".")
-
-	return (len(versionArray) == 3) &&
-		isInt(strings.Split(versionArray[0], "v")[1]) && // This checks whether the value next to the "v" is an integer
-		isInt(versionArray[1]) &&
-		isInt(versionArray[2])
+	return semver.IsValid(version)
 }

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,5 @@ require github.com/spf13/cobra v1.8.1
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	golang.org/x/mod v0.21.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,5 +6,7 @@ github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
 github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+golang.org/x/mod v0.21.0 h1:vvrHzRwRfVKSiLrG+d4FMl/Qi4ukBCE6kZlTUkDYRT0=
+golang.org/x/mod v0.21.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
This PR replaces custom semver check with a simple call to [golang.org/x/mod/semver#IsValid](https://pkg.go.dev/golang.org/x/mod/semver#IsValid)