### PR TITLE
feat: able to create aliases for local builds of Spin

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ Get the latest stable version:
 spin verman get latest
 ```
 
+## Create an alias for a local build of Spin
+
+Specify the alias name and path to Spin binary:
+
+```sh
+spin verman alias myalias /path/to/spin
+```
+
 ## Set a different version of Spin
 
 Set a specific version:
@@ -77,6 +85,12 @@ Set the latest version:
 
 ```sh
 spin verman set latest
+```
+
+Set to an alias for a local build:
+
+```sh
+spin verman set myalias
 ```
 
 ## Using `.spin-version` to Download and Set the desired Spin version
@@ -116,6 +130,12 @@ Remove a single version:
 ```sh
 # Adding the v prefix to the version is optional
 spin verman remove v2.5.0
+```
+
+Remove an alias for a local build:
+
+```sh
+spin verman rm myalias
 ```
 
 Remove all versions:

--- a/cmd/alias.go
+++ b/cmd/alias.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/spf13/cobra"
+)
+
+var aliasCmd = &cobra.Command{
+	Use:   "alias [name] [path]",
+	Short: "Creates an alias for a local Spin binary.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 2 {
+			return fmt.Errorf("invalid arguments")
+		}
+
+		versionDir, err := getVersionDir()
+		if err != nil {
+			return err
+		}
+
+		alias, filePath := args[0], args[1]
+
+		aliasPath := path.Join(versionDir, alias)
+
+		if err := os.MkdirAll(aliasPath, 0755); err != nil {
+			return err
+		}
+
+		// In the case that there is already an existing alias + symlink,
+		// this deletes the symlink (or deletes nothing if the symlink doesn't exist) so a new one can be created
+		if err := os.Remove(path.Join(aliasPath, "spin")); err != nil {
+			if !os.IsNotExist(err) { // We don't care if we are deleting nothing, so this ignores any `os.IsNotExist` errors
+				return fmt.Errorf("failed to remove old symlink: %v", err)
+			}
+		}
+
+		if err := os.Symlink(filePath, path.Join(aliasPath, "spin")); err != nil {
+			return err
+		}
+
+		fmt.Printf("Created alias %q", alias)
+
+		return nil
+	},
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -11,7 +11,7 @@ import (
 var listCmd = &cobra.Command{
 	Use:     "list",
 	Aliases: []string{"ls"},
-	Short:   "Lists all Spin versions downloaded locally.",
+	Short:   "Lists available Spin versions and aliases.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		output, err := list()
 		if err != nil {
@@ -48,7 +48,7 @@ func list() (string, error) {
 	var output []string
 
 	for _, file := range files {
-		if strings.HasPrefix(file.Name(), "v") || file.Name() == "canary" {
+		if file.Name() != "current_version" {
 			output = append(output, file.Name())
 		}
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,6 +21,8 @@ func init() {
 	// Set
 	setCmd.AddCommand(setLatestStableCmd)
 	rootCmd.AddCommand(setCmd)
+	//Alias
+	rootCmd.AddCommand(aliasCmd)
 	// Get
 	getCmd.AddCommand(getLatestStableCmd)
 	rootCmd.AddCommand(getCmd)


### PR DESCRIPTION
If you have an experimental fork of Spin that isn't available in the remote repository, this lets you alias the local build in the verman plugin

closes #5 