### PR TITLE
fix: bug in getVersionDir

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -98,8 +98,6 @@ func getVersionDir() (string, error) {
 		if err = os.MkdirAll(versionDir, 0755); err != nil {
 			return "", err
 		}
-
-		return "", nil
 	}
 
 	return versionDir, nil


### PR DESCRIPTION
The `getVersionDir` incorrectly returned an empty string when a new `versionDir` was created